### PR TITLE
Update UserController.cs

### DIFF
--- a/EMIEWebPortal.Controllers/Controllers/UserController.cs
+++ b/EMIEWebPortal.Controllers/Controllers/UserController.cs
@@ -645,7 +645,10 @@ namespace EMIEWebPortal.Controllers
         /// <returns>result of insert operation</returns>
         private int CreateNewUser(UserMapping user)
         {
-            var logonId = user.User.Email.Split('@');
+            //Updated to match what's used in the other controllers. This previously only worked if the samAccountName and email happened to be the same. 
+            var logonId = User.Identity.Name;
+            var Index = logonId.Split('\\');
+            logonId = Index[1];
 
             User newUser = new User();
             newUser.UserName = user.User.UserName;


### PR DESCRIPTION
Changing CreateNewUser to used User.Identity.Name, which matches the other controllers. This fixes an issue where users could not register if their samAccountName and email address aren't the same.